### PR TITLE
Use a partial to render social profile links

### DIFF
--- a/.personalize.toml
+++ b/.personalize.toml
@@ -3,14 +3,6 @@ Name = ""
 # Supports markdown
 About = ""
 
-# Add only the handle
-Github = ""
-Twitter = ""
-
-# Add the absolute links
-Goodreads = ""
-Linkedin = ""
-
 Email = ""
 
 # Add the filename with file extension.
@@ -18,3 +10,19 @@ Resume = ""
 
 # Sets the number of posts to display on the front page
 PostLimit = 4
+
+[[profiles]]
+name = "GitHub"
+url = ""
+
+[[profiles]]
+name = "Twitter"
+url = ""
+
+[[profiles]]
+name = "Goodreads"
+url = ""
+
+[[profiles]]
+name = "LinkedIn"
+url = ""

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,31 +9,9 @@
 	<h4>{{ .Site.Data.personalize.About| markdownify }}</h4>
 
 	<table>
-		<tr>
-			{{ if ne .Site.Data.personalize.Github "" }}
-			<td><i class="fab fa-github" aria-hidden="true"></i></td>
-			<td>&nbsp;<a href="https://github.com/{{ .Site.Data.personalize.Github }}" target="_blank">GitHub</a></td>
-			{{ end }}
-		</tr>
-		<tr>
-			{{ if ne .Site.Data.personalize.Twitter "" }}
-			<td><i class="fab fa-twitter" aria-hidden="true"></i></td>
-			<td>&nbsp;<a href="https://twitter.com/{{ .Site.Data.personalize.Twitter }}" target="_blank">Twitter</a>
-			</td>
-			{{ end }}
-		</tr>
-		<tr>
-			{{ if ne .Site.Data.personalize.Goodreads "" }}
-			<td><i class="fab fa-goodreads" aria-hidden="true"></i></td>
-			<td>&nbsp;<a href="{{ .Site.Data.personalize.Goodreads }}" target="_blank">Goodreads</a></td>
-			{{ end }}
-		</tr>
-		<tr>
-			{{ if ne .Site.Data.personalize.Linkedin "" }}
-			<td><i class="fab fa-linkedin" aria-hidden="true"></i></td>
-			<td>&nbsp;<a href="{{ .Site.Data.personalize.Linkedin }}" target="_blank">LinkedIn</a></td>
-			{{ end }}
-		</tr>
+		{{ range .Site.Data.personalize.profiles }}
+			{{ partial "profile_link.html" . }}
+		{{ end }}
 		<tr>
 			{{ if ne .Site.Data.personalize.Resume "" }}
 			<td><i class="fas fa-file-alt" aria-hidden="true"></i></td>

--- a/layouts/partials/profile_link.html
+++ b/layouts/partials/profile_link.html
@@ -1,0 +1,6 @@
+{{ if and (isset . "url") ( ne .url "") }}
+<tr>
+    <td><i class="fab fa-{{ lower .name }}" aria-hidden="true"></i></td>
+    <td>&nbsp;<a href="{{ url }}" target="_blank">{{ .name }}</a></td>
+</tr>
+{{ end }}


### PR DESCRIPTION
Instead of multiple `if` statements, use a standardized partial to render the social profile links. This should be compatible with any service with an icon in the `fontawesome` icon library.

The `.personalize.toml` config now requires all social profile links be TOML table entries with `name` and `url` keys. This is a **breaking change**, but it is more adaptable to additional social media profile links. 

Example:
```
[[profiles]]
name = "GitHub"
url = ""

[[profiles]]
name = "Twitter"
url = ""
```

